### PR TITLE
Parameter support

### DIFF
--- a/crates/rabbitmqadmin_cli/src/cli.rs
+++ b/crates/rabbitmqadmin_cli/src/cli.rs
@@ -206,7 +206,7 @@ fn list_subcommands() -> [Command; 15] {
         Command::new("parameters").arg(
             Arg::new("component")
                 .long("component")
-                .help("component (.eg. federation-upstream, vhost-limits)")
+                .help("component (for example: federation-upstream, vhost-limits)")
                 .required(false),
         ),
         Command::new("policies"),

--- a/crates/rabbitmqadmin_cli/src/cli.rs
+++ b/crates/rabbitmqadmin_cli/src/cli.rs
@@ -203,7 +203,12 @@ fn list_subcommands() -> [Command; 15] {
         Command::new("exchanges"),
         Command::new("bindings"),
         Command::new("consumers"),
-        Command::new("parameters"),
+        Command::new("parameters").arg(
+            Arg::new("component")
+                .long("component")
+                .help("component (eg. federation-upstream)")
+                .required(false),
+        ),
         Command::new("policies"),
         Command::new("operator_policies"),
         Command::new("vhost_limits"),
@@ -403,7 +408,24 @@ fn declare_subcommands() -> [Command; 11] {
                     .default_value("{}")
                     .value_parser(clap::value_parser!(String)),
             ),
-        Command::new("parameter").about("sets a runtime parameter"),
+        Command::new("parameter").
+            about("sets a runtime parameter").
+            arg(
+                Arg::new("name")
+                    .long("name")
+                    .help("parameter's name")
+                    .required(true)
+            ).
+            arg(
+                Arg::new("component")
+                    .long("component")
+                    .help("component (eg. federation)")
+                    .required(true))
+            .arg(
+                Arg::new("value")
+                    .long("value")
+                    .help("parameter's value")
+                    .required(true)),
         Command::new("policy")
             .about("creates or updates a policy")
             .arg(
@@ -575,7 +597,20 @@ fn delete_subcommands() -> [Command; 11] {
                     .default_value("{}")
                     .value_parser(clap::value_parser!(String)),
             ),
-        Command::new("parameter").about("clears a runtime parameter"),
+        Command::new("parameter")
+            .about("clears a runtime parameter")
+            .arg(
+                Arg::new("name")
+                    .long("name")
+                    .help("parameter's name")
+                    .required(true),
+            )
+            .arg(
+                Arg::new("component")
+                    .long("component")
+                    .help("component (eg. federation-upstream)")
+                    .required(true),
+            ),
         Command::new("policy").about("deletes a policy").arg(
             Arg::new("name")
                 .long("name")

--- a/crates/rabbitmqadmin_cli/src/cli.rs
+++ b/crates/rabbitmqadmin_cli/src/cli.rs
@@ -206,7 +206,7 @@ fn list_subcommands() -> [Command; 15] {
         Command::new("parameters").arg(
             Arg::new("component")
                 .long("component")
-                .help("component (eg. federation-upstream)")
+                .help("component (.eg. federation-upstream, vhost-limits)")
                 .required(false),
         ),
         Command::new("policies"),

--- a/crates/rabbitmqadmin_cli/src/main.rs
+++ b/crates/rabbitmqadmin_cli/src/main.rs
@@ -67,7 +67,7 @@ fn main() {
                     print_result_or_fail(result);
                 }
                 ("list", "parameters") => {
-                    let result = commands::list_parameters(&cli);
+                    let result = commands::list_parameters(&cli, command_args);
                     print_result_or_fail(result);
                 }
                 ("list", "exchanges") => {
@@ -118,6 +118,10 @@ fn main() {
                     let result = commands::declare_user_limit(&cli, command_args);
                     print_result_or_fail(result);
                 }
+                ("declare", "parameter") => {
+                    let result = commands::declare_parameter(&cli, command_args);
+                    print_result_or_fail(result);
+                }
                 ("delete", "vhost") => {
                     let result = commands::delete_vhost(&cli, command_args);
                     print_result_or_fail(result);
@@ -152,6 +156,10 @@ fn main() {
                 }
                 ("delete", "user_limit") => {
                     let result = commands::delete_user_limit(&cli, command_args);
+                    print_result_or_fail(result);
+                }
+                ("delete", "parameter") => {
+                    let result = commands::delete_parameter(&cli, command_args);
                     print_result_or_fail(result);
                 }
                 ("purge", "queue") => {


### PR DESCRIPTION
We don't have an endpoint to return all parameters for a given vhost, so I added client-side filtering to only show the parameters for the target vhost (`-V` or `/`).